### PR TITLE
allow normal villagers to be hired also, and leave citizens2 npcs alone

### DIFF
--- a/src/main/java/com/nisovin/shopkeepers/Settings.java
+++ b/src/main/java/com/nisovin/shopkeepers/Settings.java
@@ -4,10 +4,13 @@ import java.lang.reflect.Field;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.Configuration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class Settings {
 	
 	public static boolean disableOtherVillagers = true;
+	public static boolean hireOtherVillagers = true;
 	public static boolean blockVillagerSpawns = false;
 	public static boolean enableSpawnVerifier = false;
 	public static boolean bypassSpawnBlocking = true;
@@ -96,6 +99,7 @@ public class Settings {
 	
 	public static String msgHired = "&aYou have hired this shopkeeper!";
 	public static String msgCantHire = "&aYou cannot afford to hire this shopkeeper.";
+	public static String msgForHire = "&aThe villager offered his services as a shopkeeper in exchange for " + hireItem.toString() + ".";
 	
 	public static String msgPlayerShopCreated = "&aShopkeeper created!\n&aAdd items you want to sell to your chest, then\n&aright-click the shop while sneaking to modify costs.";
 	public static String msgBookShopCreated = "&aShopkeeper created!\n&aAdd written books and blank books to your chest, then\n&aright-click the shop while sneaking to modify costs.";
@@ -170,6 +174,16 @@ public class Settings {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+	
+	public static ItemStack createCreationItem() {
+		ItemStack creationItem = new ItemStack(shopCreationItem, 1, (short)shopCreationItemData);
+		if (shopCreationItemName != null && !shopCreationItemName.isEmpty()) {
+			ItemMeta meta = creationItem.getItemMeta();
+			meta.setDisplayName(shopCreationItemName);
+			creationItem.setItemMeta(meta);
+		}
+		return creationItem;
 	}
 	
 }

--- a/src/main/java/com/nisovin/shopkeepers/ShopListener.java
+++ b/src/main/java/com/nisovin/shopkeepers/ShopListener.java
@@ -110,12 +110,7 @@ class ShopListener implements Listener {
 						
 						// return egg
 						if (Settings.deletingPlayerShopReturnsEgg && shopkeeper instanceof PlayerShopkeeper) {
-							ItemStack creationItem = new ItemStack(Settings.shopCreationItem, 1, (short)Settings.shopCreationItemData);
-							if (Settings.shopCreationItemName != null && !Settings.shopCreationItemName.isEmpty()) {
-								ItemMeta meta = creationItem.getItemMeta();
-								meta.setDisplayName(Settings.shopCreationItemName);
-								creationItem.setItemMeta(meta);
-							}
+							ItemStack creationItem = Settings.createCreationItem();
 							HashMap<Integer, ItemStack> remaining = event.getWhoClicked().getInventory().addItem(creationItem);
 							if (!remaining.isEmpty()) {
 								event.getWhoClicked().getWorld().dropItem(shopkeeper.getActualLocation(), creationItem);

--- a/src/main/java/com/nisovin/shopkeepers/ShopkeepersPlugin.java
+++ b/src/main/java/com/nisovin/shopkeepers/ShopkeepersPlugin.java
@@ -31,6 +31,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -700,6 +701,29 @@ public class ShopkeepersPlugin extends JavaPlugin {
 				purchasing.put(player.getName(), shopkeeper.getId());
 				ShopkeepersPlugin.debug("  Trade window opened");
 			}
+		}
+	}
+	
+	void handleHireVillager(Player player, Villager villager) {
+		// hire him if holding his hiring item
+		ItemStack inHand = player.getItemInHand();
+		if (inHand != null && inHand.getType() == Settings.hireItem) {
+			inHand.setAmount(inHand.getAmount() - 1);
+			player.setItemInHand(inHand);
+
+			// give player the creation item
+			ItemStack creationItem = Settings.createCreationItem();
+			HashMap<Integer, ItemStack> remaining = player.getInventory().addItem(creationItem);
+			if (!remaining.isEmpty()) {
+				villager.getWorld().dropItem(villager.getLocation(), creationItem);
+			}
+
+			// remove the npc
+			villager.remove();
+			
+			sendMessage(player, Settings.msgHired);
+		} else {
+			sendMessage(player, Settings.msgForHire);
 		}
 	}
 	

--- a/src/main/java/com/nisovin/shopkeepers/VillagerListener.java
+++ b/src/main/java/com/nisovin/shopkeepers/VillagerListener.java
@@ -27,6 +27,14 @@ public class VillagerListener implements Listener {
 			} else if (shopkeeper != null) {
 				plugin.handleShopkeeperInteraction(event.getPlayer(), shopkeeper);
 				event.setCancelled(true);
+			} else if (shopkeeper == null && villager.hasMetadata("NPC")) {
+				// ignore any interaction with citizens2 NPCs
+				return;
+			} else if (Settings.hireOtherVillagers) {
+				// allow hiring of other villagers
+				ShopkeepersPlugin.debug("  Non-shopkeeper, possible hire");
+				plugin.handleHireVillager(event.getPlayer(), villager);
+				event.setCancelled(true);
 			} else if (Settings.disableOtherVillagers) {
 				// don't allow trading with other villagers
 				ShopkeepersPlugin.debug("  Non-shopkeeper, trade prevented");


### PR DESCRIPTION
adds the option of allowing players to hire naturally spawning wandering villagers, gives them the creation item so they can deploy it wherever
