### PR TITLE
Survival/Raiding Tweaks

### DIFF
--- a/src/main/java/com/nisovin/shopkeepers/RemoveShopOnChestBreakListener.java
+++ b/src/main/java/com/nisovin/shopkeepers/RemoveShopOnChestBreakListener.java
@@ -27,9 +27,9 @@ class RemoveShopOnChestBreakListener implements Listener {
 			if (shopkeepers.size() > 0) {
 				for (PlayerShopkeeper shopkeeper : shopkeepers) {
 					// return creation item for player shopkeepers:
-					if (Settings.deletingPlayerShopReturnsCreationItem && shopkeeper.getType().isPlayerShopType()) {
+					if (Settings.deletingPlayerShopReturnsCreationItem) {
 						ItemStack creationItem = Settings.createCreationItem();
-						block.getWorld().dropItem(shopkeeper.getActualLocation(), creationItem);
+						block.getWorld().dropItem(block.getLocation(), creationItem);
 					}
 					plugin.deleteShopkeeper(shopkeeper);
 				}

--- a/src/main/java/com/nisovin/shopkeepers/RemoveShopOnChestBreakListener.java
+++ b/src/main/java/com/nisovin/shopkeepers/RemoveShopOnChestBreakListener.java
@@ -7,6 +7,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
 
 import com.nisovin.shopkeepers.shoptypes.PlayerShopkeeper;
 
@@ -25,6 +26,11 @@ class RemoveShopOnChestBreakListener implements Listener {
 			List<PlayerShopkeeper> shopkeepers = plugin.getProtectedChests().getShopkeeperOwnersOfChest(block);
 			if (shopkeepers.size() > 0) {
 				for (PlayerShopkeeper shopkeeper : shopkeepers) {
+					// return creation item for player shopkeepers:
+					if (Settings.deletingPlayerShopReturnsCreationItem && shopkeeper.getType().isPlayerShopType()) {
+						ItemStack creationItem = Settings.createCreationItem();
+						block.getWorld().dropItem(shopkeeper.getActualLocation(), creationItem);
+					}
 					plugin.deleteShopkeeper(shopkeeper);
 				}
 				plugin.save();

--- a/src/main/java/com/nisovin/shopkeepers/Settings.java
+++ b/src/main/java/com/nisovin/shopkeepers/Settings.java
@@ -74,10 +74,13 @@ public class Settings {
 	public static String nameplatePrefix = "&a";
 	public static String nameRegex = "[A-Za-z0-9 ]{3,32}";
 	public static boolean allowRenamingOfPlayerNpcShops = false;
+	public static boolean allowChestAccessOnPlayerNpcShops = false;
 
 	public static String editorTitle = "Shopkeeper Editor";
 	public static Material nameItem = Material.ANVIL;
 	public static int nameItemData = 0;
+	public static Material chestItem = Material.CHEST;
+	public static int chestItemData = 0;
 	public static Material deleteItem = Material.BONE;
 	public static int deleteItemData = 0;
 
@@ -115,6 +118,8 @@ public class Settings {
 
 	public static String msgButtonName = "&aSet Shop Name";
 	public static List<String> msgButtonNameLore = Arrays.asList("Lets you rename", "your shopkeeper");
+	public static String msgButtonChest = "&aView Chest Inventory";
+	public static List<String> msgButtonChestLore = Arrays.asList("Lets you view the inventory", " your shopkeeper is using");
 	public static String msgButtonType = "&aChoose Appearance";
 	public static List<String> msgButtonTypeLore = Arrays.asList("Changes the look", "of your shopkeeper");
 	public static String msgButtonDelete = "&4Delete";
@@ -308,6 +313,10 @@ public class Settings {
 
 	public static ItemStack createNameButtonItem() {
 		return Utils.createItemStack(nameItem, 1, (short) nameItemData, msgButtonName, msgButtonNameLore);
+	}
+
+	public static ItemStack createChestButtonItem() {
+		return Utils.createItemStack(chestItem, 1, (short) chestItemData, msgButtonChest, msgButtonChestLore);
 	}
 
 	public static ItemStack createDeleteButtonItem() {

--- a/src/main/java/com/nisovin/shopkeepers/Settings.java
+++ b/src/main/java/com/nisovin/shopkeepers/Settings.java
@@ -77,11 +77,11 @@ public class Settings {
 	public static boolean allowChestAccessOnPlayerNpcShops = false;
 
 	public static String editorTitle = "Shopkeeper Editor";
-	public static Material nameItem = Material.ANVIL;
+	public static Material nameItem = Material.NAME_TAG;
 	public static int nameItemData = 0;
 	public static Material chestItem = Material.CHEST;
 	public static int chestItemData = 0;
-	public static Material deleteItem = Material.BONE;
+	public static Material deleteItem = Material.BARRIER;
 	public static int deleteItemData = 0;
 
 	public static Material hireItem = Material.EMERALD;

--- a/src/main/java/com/nisovin/shopkeepers/Settings.java
+++ b/src/main/java/com/nisovin/shopkeepers/Settings.java
@@ -49,6 +49,7 @@ public class Settings {
 	public static List<String> shopCreationItemLore = new ArrayList<String>(0);
 	public static boolean preventShopCreationItemRegularUsage = false;
 	public static boolean deletingPlayerShopReturnsCreationItem = false;
+	public static boolean replaceVillagerEggsWithCreationItem = false;
 
 	public static List<String> enabledLivingShops = Arrays.asList(
 			EntityType.VILLAGER.name(), EntityType.COW.name(),

--- a/src/main/java/com/nisovin/shopkeepers/Settings.java
+++ b/src/main/java/com/nisovin/shopkeepers/Settings.java
@@ -75,7 +75,7 @@ public class Settings {
 	public static String nameplatePrefix = "&a";
 	public static String nameRegex = "[A-Za-z0-9 ]{3,32}";
 	public static boolean allowRenamingOfPlayerNpcShops = false;
-	public static boolean allowChestAccessOnPlayerNpcShops = false;
+	public static boolean enableChestOptionOnPlayerShop = false;
 
 	public static String editorTitle = "Shopkeeper Editor";
 	public static Material nameItem = Material.NAME_TAG;

--- a/src/main/java/com/nisovin/shopkeepers/Shopkeeper.java
+++ b/src/main/java/com/nisovin/shopkeepers/Shopkeeper.java
@@ -472,10 +472,10 @@ public abstract class Shopkeeper {
 	 * Fails if this shopkeeper type doesn't have a chest (ex. admin shops).
 	 * 
 	 * @param player
-	 *            the player requesting the hiring interface
-	 * @return whether or not the player's request was successful and the player is now hiring
+	 *            the player requesting the chest inventory window
+	 * @return whether or not the player's request was successful and inventory window opened
 	 */
-	public boolean openChestWindow(final Player player) {
+	public boolean openChestWindow(Player player) {
 		return false;
 	}
 

--- a/src/main/java/com/nisovin/shopkeepers/Shopkeeper.java
+++ b/src/main/java/com/nisovin/shopkeepers/Shopkeeper.java
@@ -467,6 +467,18 @@ public abstract class Shopkeeper {
 		return this.openWindow(DefaultUIs.HIRING_WINDOW.getIdentifier(), player);
 	}
 
+	/**
+	 * Attempts to open the chest inventory of this shopkeeper for the specified player.
+	 * Fails if this shopkeeper type doesn't have a chest (ex. admin shops).
+	 * 
+	 * @param player
+	 *            the player requesting the hiring interface
+	 * @return whether or not the player's request was successful and the player is now hiring
+	 */
+	public boolean openChestWindow(final Player player) {
+		return false;
+	}
+
 	// NAMING:
 
 	public void startNaming(Player player) {

--- a/src/main/java/com/nisovin/shopkeepers/ShopkeepersPlugin.java
+++ b/src/main/java/com/nisovin/shopkeepers/ShopkeepersPlugin.java
@@ -206,7 +206,7 @@ public class ShopkeepersPlugin extends JavaPlugin implements ShopkeepersAPI {
 		pm.registerEvents(new CreateListener(this), this);
 		pm.registerEvents(new VillagerInteractionListener(this), this);
 		pm.registerEvents(new LivingEntityShopListener(this), this);
-
+		
 		if (Settings.enableSignShops) {
 			this.signShopListener = new SignShopListener(this);
 			pm.registerEvents(signShopListener, this);
@@ -230,6 +230,10 @@ public class ShopkeepersPlugin extends JavaPlugin implements ShopkeepersAPI {
 		if (Settings.bypassSpawnBlocking) {
 			creatureForceSpawnListener = new CreatureForceSpawnListener();
 			Bukkit.getPluginManager().registerEvents(creatureForceSpawnListener, this);
+		}
+
+		if (Settings.replaceVillagerEggsWithCreationItem) {
+			pm.registerEvents(new SpawnEggListener(this), this);
 		}
 
 		// register command handler:

--- a/src/main/java/com/nisovin/shopkeepers/SpawnEggListener.java
+++ b/src/main/java/com/nisovin/shopkeepers/SpawnEggListener.java
@@ -1,0 +1,53 @@
+package com.nisovin.shopkeepers;
+
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+
+import com.nisovin.shopkeepers.compat.NMSManager;
+
+/*
+ * Just converts the old spawn eggs into the new shopcreation item when they try to use one
+ */
+
+class SpawnEggListener implements Listener {
+
+	private final ShopkeepersPlugin plugin;
+
+	SpawnEggListener(ShopkeepersPlugin plugin) {
+		this.plugin = plugin;
+	}
+
+	@EventHandler(ignoreCancelled = true)
+	void onPlayerInteract(PlayerInteractEvent event) {
+		if(event.getMaterial() == Material.MONSTER_EGG && !event.getPlayer().isOp() && event.getPlayer().getGameMode() != GameMode.CREATIVE) {
+			// this magic string is apparently a villager egg for some reason..
+			if(event.getItem().toString().contains("internal=H4sIAAAAAAAAAONiYOBi4HTNK8ksqQxJTOdgYMpMYeAIy8zJSUxPLWJgAADlEwUxIAAAAA==")) {
+				event.setCancelled(true);
+
+				if(!NMSManager.getProvider().isMainHandInteraction(event)) {
+					return;
+				}
+
+				final Player player = event.getPlayer();
+				final ItemStack newItems = Settings.createCreationItem();
+				int amount = event.getItem().getAmount();
+				newItems.setAmount(amount);
+
+				Utils.sendMessage(player, "replacing " + amount + " villager egg(s) with " + amount + " " + Settings.shopCreationItemName + "(s)");
+				
+				Bukkit.getScheduler().runTaskLater(plugin, new Runnable() {
+					@Override
+					public void run() {
+						player.setItemInHand(newItems);
+					}
+				}, 1);
+			}
+		}
+	}
+}

--- a/src/main/java/com/nisovin/shopkeepers/SpawnEggListener.java
+++ b/src/main/java/com/nisovin/shopkeepers/SpawnEggListener.java
@@ -25,12 +25,12 @@ class SpawnEggListener implements Listener {
 
 	@EventHandler(ignoreCancelled = true)
 	void onPlayerInteract(PlayerInteractEvent event) {
-		if(event.getMaterial() == Material.MONSTER_EGG && !event.getPlayer().isOp() && event.getPlayer().getGameMode() != GameMode.CREATIVE) {
+		if (event.getMaterial() == Material.MONSTER_EGG && !event.getPlayer().isOp() && event.getPlayer().getGameMode() != GameMode.CREATIVE) {
 			// this magic string is apparently a villager egg for some reason..
-			if(event.getItem().toString().contains("internal=H4sIAAAAAAAAAONiYOBi4HTNK8ksqQxJTOdgYMpMYeAIy8zJSUxPLWJgAADlEwUxIAAAAA==")) {
+			if (event.getItem().toString().contains("internal=H4sIAAAAAAAAAONiYOBi4HTNK8ksqQxJTOdgYMpMYeAIy8zJSUxPLWJgAADlEwUxIAAAAA==")) {
 				event.setCancelled(true);
 
-				if(!NMSManager.getProvider().isMainHandInteraction(event)) {
+				if (!NMSManager.getProvider().isMainHandInteraction(event)) {
 					return;
 				}
 
@@ -40,7 +40,7 @@ class SpawnEggListener implements Listener {
 				newItems.setAmount(amount);
 
 				Utils.sendMessage(player, "replacing " + amount + " villager egg(s) with " + amount + " " + Settings.shopCreationItemName + "(s)");
-				
+
 				Bukkit.getScheduler().runTaskLater(plugin, new Runnable() {
 					@Override
 					public void run() {

--- a/src/main/java/com/nisovin/shopkeepers/TestEntityDamageByEntityEvent.java
+++ b/src/main/java/com/nisovin/shopkeepers/TestEntityDamageByEntityEvent.java
@@ -2,13 +2,12 @@ package com.nisovin.shopkeepers;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 /**
- * A test event that is called when we check if something can be interacted with (Chests)
+ * A test event that is called to check that villagers can be removed/hired
  */
 public class TestEntityDamageByEntityEvent extends EntityDamageByEntityEvent {
+
 	public TestEntityDamageByEntityEvent(Entity damager, Entity damagee) {
 		super(damager, damagee, DamageCause.CUSTOM, 1);
 	}

--- a/src/main/java/com/nisovin/shopkeepers/TestEntityDamageByEntityEvent.java
+++ b/src/main/java/com/nisovin/shopkeepers/TestEntityDamageByEntityEvent.java
@@ -1,0 +1,15 @@
+package com.nisovin.shopkeepers;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+
+/**
+ * A test event that is called when we check if something can be interacted with (Chests)
+ */
+public class TestEntityDamageByEntityEvent extends EntityDamageByEntityEvent {
+	public TestEntityDamageByEntityEvent(Entity damager, Entity damagee) {
+		super(damager, damagee, DamageCause.CUSTOM, 1);
+	}
+}

--- a/src/main/java/com/nisovin/shopkeepers/VillagerInteractionListener.java
+++ b/src/main/java/com/nisovin/shopkeepers/VillagerInteractionListener.java
@@ -61,6 +61,14 @@ class VillagerInteractionListener implements Listener {
 
 	// returns false, if the player wasn't able to hire this villager
 	private boolean handleHireOtherVillager(Player player, Villager villager) {
+		// check if the player has access to remove the entity (incase its protected by another mod)
+		Log.debug("    checking villager access ..");
+		TestEntityDamageByEntityEvent fakeDamageEvent = new TestEntityDamageByEntityEvent(player, villager);
+		plugin.getServer().getPluginManager().callEvent(fakeDamageEvent);
+		if (fakeDamageEvent.isCancelled()) {
+			Log.debug("    no permission to remove villager");
+			return false;
+		}
 		// hire him if holding his hiring item
 		ItemStack inHand = player.getItemInHand();
 		if (!Settings.isHireItem(inHand)) {

--- a/src/main/java/com/nisovin/shopkeepers/shoptypes/PlayerShopkeeper.java
+++ b/src/main/java/com/nisovin/shopkeepers/shoptypes/PlayerShopkeeper.java
@@ -354,6 +354,27 @@ public abstract class PlayerShopkeeper extends Shopkeeper {
 		// unregister previously protected chest:
 		ShopkeepersPlugin.getInstance().getProtectedChests().removeChest(worldName, chestX, chestY, chestZ, this);
 	}
+	
+	@Override
+	public boolean openChestWindow(final Player player) {
+		Log.debug("checking open chest window ..");
+		// make sure the chest still exists
+		Block chest = this.getChest();
+		if (Utils.isChest(chest.getType())) {
+			final Inventory inv = ((Chest) chest.getState()).getInventory();
+			
+			// open the chest directly as the player (no need for a custom UI)
+			Bukkit.getScheduler().runTaskLater(ShopkeepersPlugin.getInstance(), new Runnable() {
+				@Override
+				public void run() {
+					Log.debug("opening chest inventory window");
+					player.openInventory(inv);
+				}
+			}, 2L);
+			return true;
+		}
+		return false;
+	}
 
 	@Override
 	protected void onPlayerInteraction(Player player) {

--- a/src/main/java/com/nisovin/shopkeepers/shoptypes/PlayerShopkeeper.java
+++ b/src/main/java/com/nisovin/shopkeepers/shoptypes/PlayerShopkeeper.java
@@ -356,33 +356,28 @@ public abstract class PlayerShopkeeper extends Shopkeeper {
 		// unregister previously protected chest:
 		ShopkeepersPlugin.getInstance().getProtectedChests().removeChest(worldName, chestX, chestY, chestZ, this);
 	}
-	
+
 	@Override
-	public boolean openChestWindow(final Player player) {
+	public boolean openChestWindow(Player player) {
 		Log.debug("checking open chest window ..");
 		// make sure the chest still exists
 		Block chest = this.getChest();
 		if (Utils.isChest(chest.getType())) {
 			final Inventory inv = ((Chest) chest.getState()).getInventory();
-			
+
 			// open the chest directly as the player (no need for a custom UI)
-			Bukkit.getScheduler().runTaskLater(ShopkeepersPlugin.getInstance(), new Runnable() {
-				@Override
-				public void run() {
-					Log.debug("opening chest inventory window");
-					player.openInventory(inv);
-				}
-			}, 2L);
+			Log.debug("opening chest inventory window");
+			player.openInventory(inv);
 			return true;
 		}
 		return false;
 	}
-	
+
 	@Override
 	protected void onPlayerInteraction(Player player) {
 		PlayerShopEditorHandler editorHandler = (PlayerShopEditorHandler) this.getUIHandler(DefaultUIs.EDITOR_WINDOW.getIdentifier());
-		if(Settings.allowRenamingOfPlayerNpcShops && player.getItemInHand().getType() == Settings.nameItem && editorHandler.canOpen(player)) {
-			renameWithItem(player);
+		if (Settings.allowRenamingOfPlayerNpcShops && player.getItemInHand().getType() == Settings.nameItem && editorHandler.canOpen(player)) {
+			this.renameWithItem(player);
 			return;
 		}
 		// TODO what if something is replacing the default PlayerShopHiringHandler with some other kind of handler?
@@ -562,14 +557,14 @@ public abstract class PlayerShopkeeper extends Shopkeeper {
 	public Block getChest() {
 		return Bukkit.getWorld(worldName).getBlockAt(chestX, chestY, chestZ);
 	}
-	
+
 	/**
 	 * Renames the shopkeeper using the item the player is holding (ideally a name tag)
 	 */
 	protected void renameWithItem(final Player player) {
 		ItemMeta itemMeta = player.getItemInHand().getItemMeta();
 		
-		if(!itemMeta.hasDisplayName()) {
+		if (!itemMeta.hasDisplayName()) {
 			setName("");
 		} else {
 			String newName = itemMeta.getDisplayName();

--- a/src/main/java/com/nisovin/shopkeepers/ui/defaults/EditorHandler.java
+++ b/src/main/java/com/nisovin/shopkeepers/ui/defaults/EditorHandler.java
@@ -95,7 +95,7 @@ public abstract class EditorHandler extends UIHandler {
 			// save:
 			ShopkeepersPlugin.getInstance().save();
 		} else if (slot == 8) {
-			if (!Settings.allowChestAccessOnPlayerNpcShops && !Settings.allowRenamingOfPlayerNpcShops && shopkeeper.getType().isPlayerShopType() && shopkeeper.getShopObject().getObjectType() == DefaultShopObjectTypes.CITIZEN()) {
+			if (!Settings.enableChestOptionOnPlayerShop && !Settings.allowRenamingOfPlayerNpcShops && shopkeeper.getType().isPlayerShopType() && shopkeeper.getShopObject().getObjectType() == DefaultShopObjectTypes.CITIZEN()) {
 				return; // renaming is disabled for citizens player shops
 				// TODO restructure this all, to allow for dynamic editor buttons depending on shop (object) types and
 				// settings
@@ -129,14 +129,19 @@ public abstract class EditorHandler extends UIHandler {
 				}
 			}, 1L);
 
-			if(event.getCurrentItem().getType() == Settings.nameItem) {
+			if (event.getCurrentItem().getType() == Settings.nameItem) {
 				// start naming:
 				shopkeeper.startNaming(player);
 				Utils.sendMessage(player, Settings.msgTypeNewName);
-			} else if(event.getCurrentItem().getType() == Settings.chestItem) {
-				shopkeeper.openChestWindow(player);
+			} else if (event.getCurrentItem().getType() == Settings.chestItem) {
+				Bukkit.getScheduler().runTaskLater(ShopkeepersPlugin.getInstance(), new Runnable() {
+
+					@Override
+					public void run() {
+						shopkeeper.openChestWindow(player);
+					}
+				}, 2L);
 			}
-			
 		}
 	}
 
@@ -173,7 +178,7 @@ public abstract class EditorHandler extends UIHandler {
 
 	protected void setActionButtons(Inventory inventory) {
 		// no naming button for citizens player shops if renaming id disabled for those
-		if (Settings.allowChestAccessOnPlayerNpcShops && shopkeeper.getType().isPlayerShopType()) {
+		if (Settings.enableChestOptionOnPlayerShop && shopkeeper.getType().isPlayerShopType()) {
 			inventory.setItem(8, Settings.createChestButtonItem());
 		} else if (Settings.allowRenamingOfPlayerNpcShops || !shopkeeper.getType().isPlayerShopType() || shopkeeper.getShopObject().getObjectType() != DefaultShopObjectTypes.CITIZEN()) {
 			inventory.setItem(8, Settings.createNameButtonItem());

--- a/src/main/java/com/nisovin/shopkeepers/ui/defaults/EditorHandler.java
+++ b/src/main/java/com/nisovin/shopkeepers/ui/defaults/EditorHandler.java
@@ -95,13 +95,13 @@ public abstract class EditorHandler extends UIHandler {
 			// save:
 			ShopkeepersPlugin.getInstance().save();
 		} else if (slot == 8) {
-			if (!Settings.allowRenamingOfPlayerNpcShops && shopkeeper.getType().isPlayerShopType() && shopkeeper.getShopObject().getObjectType() == DefaultShopObjectTypes.CITIZEN()) {
+			if (!Settings.allowChestAccessOnPlayerNpcShops && !Settings.allowRenamingOfPlayerNpcShops && shopkeeper.getType().isPlayerShopType() && shopkeeper.getShopObject().getObjectType() == DefaultShopObjectTypes.CITIZEN()) {
 				return; // renaming is disabled for citizens player shops
 				// TODO restructure this all, to allow for dynamic editor buttons depending on shop (object) types and
 				// settings
 			}
 
-			// name button - ask for new name:
+			// name or chest inventory button
 			event.setCancelled(true);
 
 			// prepare closing the editor window:
@@ -129,9 +129,14 @@ public abstract class EditorHandler extends UIHandler {
 				}
 			}, 1L);
 
-			// start naming:
-			shopkeeper.startNaming(player);
-			Utils.sendMessage(player, Settings.msgTypeNewName);
+			if(event.getCurrentItem().getType() == Settings.nameItem) {
+				// start naming:
+				shopkeeper.startNaming(player);
+				Utils.sendMessage(player, Settings.msgTypeNewName);
+			} else if(event.getCurrentItem().getType() == Settings.chestItem) {
+				shopkeeper.openChestWindow(player);
+			}
+			
 		}
 	}
 
@@ -168,7 +173,9 @@ public abstract class EditorHandler extends UIHandler {
 
 	protected void setActionButtons(Inventory inventory) {
 		// no naming button for citizens player shops if renaming id disabled for those
-		if (Settings.allowRenamingOfPlayerNpcShops || !shopkeeper.getType().isPlayerShopType() || shopkeeper.getShopObject().getObjectType() != DefaultShopObjectTypes.CITIZEN()) {
+		if (Settings.allowChestAccessOnPlayerNpcShops && shopkeeper.getType().isPlayerShopType()) {
+			inventory.setItem(8, Settings.createChestButtonItem());
+		} else if (Settings.allowRenamingOfPlayerNpcShops || !shopkeeper.getType().isPlayerShopType() || shopkeeper.getShopObject().getObjectType() != DefaultShopObjectTypes.CITIZEN()) {
 			inventory.setItem(8, Settings.createNameButtonItem());
 			// TODO restructure this, so that the button types can be registered and unregistered (instead of this
 			// condition check here)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -65,10 +65,13 @@ always-show-nameplates: false
 nameplate-prefix: "&a"
 name-regex: "[A-Za-z0-9 ]{3,25}"
 allow-renaming-of-player-npc-shops: false
+allow-chest-access-on-player-npc-shops: false
 
 editor-title: "Shopkeeper Editor"
 name-item: ANVIL
 name-item-data: 0
+chest-item: CHEST
+chest-item-data: 0
 delete-item: BONE
 delete-item-data: 0
 
@@ -111,6 +114,10 @@ msg-button-name: "&aSet Shop Name"
 msg-button-name-lore:
 - Lets you rename
 - your shopkeeper
+msg-button-chest: '&aView Chest Inventory'
+msg-button-chest-lore:
+- Lets you view the inventory
+- ' your shopkeeper is using'
 msg-button-type: "&aChoose Appearance"
 msg-button-type-lore:
 - Changes the look

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -68,11 +68,11 @@ allow-renaming-of-player-npc-shops: false
 allow-chest-access-on-player-npc-shops: false
 
 editor-title: "Shopkeeper Editor"
-name-item: ANVIL
+name-item: NAME_TAG
 name-item-data: 0
 chest-item: CHEST
 chest-item-data: 0
-delete-item: BONE
+delete-item: BARRIER
 delete-item-data: 0
 
 hire-item: EMERALD

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,6 +35,7 @@ shop-creation-item-name: ""
 shop-creation-item-lore: []
 prevent-shop-creation-item-regular-usage: false
 deleting-player-shop-returns-creation-item: false
+replace-villager-eggs-with-creation-item: false
 
 enabled-living-shops:
 - VILLAGER

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -66,7 +66,7 @@ always-show-nameplates: false
 nameplate-prefix: "&a"
 name-regex: "[A-Za-z0-9 ]{3,25}"
 allow-renaming-of-player-npc-shops: false
-allow-chest-access-on-player-npc-shops: false
+enable-chest-option-on-player-shop: false
 
 editor-title: "Shopkeeper Editor"
 name-item: NAME_TAG
@@ -115,10 +115,10 @@ msg-button-name: "&aSet Shop Name"
 msg-button-name-lore:
 - Lets you rename
 - your shopkeeper
-msg-button-chest: '&aView Chest Inventory'
+msg-button-chest: "&aView Chest Inventory"
 msg-button-chest-lore:
 - Lets you view the inventory
-- ' your shopkeeper is using'
+- your shopkeeper is using
 msg-button-type: "&aChoose Appearance"
 msg-button-type-lore:
 - Changes the look


### PR DESCRIPTION
several addition to help player shops fit in well on survival/pvp type servers where raiding is possible

- prevent players from stealing villagers who are protected by mods

- remove shopkeeper and return shop creation item when chest is broken

- open the chest inventory through the editor window, helpful on servers where the chest can be hidden or surrounded by protected blocks

- provide a new way to rename villagers using the rename item

- updated button defaults to use new images, the nametag for renaming, and the barrier block for close

